### PR TITLE
use len() instead of size method for list values

### DIFF
--- a/densratio/uLSIF.py
+++ b/densratio/uLSIF.py
@@ -31,7 +31,7 @@ def uLSIF(x, y, sigma_range, lambda_range, kernel_num = 100, verbose = True):
     if verbose:
         print("################## Start uLSIF ##################")
 
-    if sigma_range.size == 1 and lambda_range.size == 1:
+    if len(sigma_range) == 1 and len(lambda_range) == 1:
         sigma = sigma_range[0]
         lambda_ = lambda_range[0]
     else:


### PR DESCRIPTION
According to its document `uLSIF()` takes list of float values as `sigma_range` and `lambda_range`, but it use their size method that are for numpy arrays but not for lists.
This PR replaces `size` method with `len()` so that list arguments are processed as expected.