### PR TITLE
Compute kernel Gaussian performance improvements.

### DIFF
--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -13,6 +13,7 @@ References:
 from numpy import array, asarray, asmatrix, diag, empty, exp, inf, log, matrix, multiply, ones, power, sum
 from numpy.random import randint
 from numpy.linalg import solve
+from warnings import warn
 from .density_ratio import DensityRatio, KernelInfo
 from .helpers import guvectorize_compute, np_float, to_numpy_matrix
 
@@ -210,3 +211,15 @@ _compute_function = _compute_functions['cpu' if 'cpu' in _compute_functions else
 # Returns a 2D numpy matrix of kernel evaluated at the gridpoints with coordinates from x_list and y_list.
 def compute_kernel_Gaussian(x_list, y_list, sigma):
     return _compute_function(x_list, y_list, -.5 * sigma ** -2).T
+
+
+def set_compute_kernel_target(target: str) -> None:
+    global _compute_function
+    if target not in ('numpy', 'cpu', 'parallel'):
+        raise ValueError('\'target\' must be one of the following: \'numpy\', \'cpu\', or \'parallel\'.')
+
+    if target not in _compute_functions:
+        warn('\'numba\' not available; defaulting to \'numpy\'.', ImportWarning)
+        target = 'numpy'
+
+    _compute_function = _compute_functions[target]

--- a/densratio/__init__.py
+++ b/densratio/__init__.py
@@ -1,1 +1,7 @@
+from warnings import filterwarnings
 from .core import densratio
+from .RuLSIF import set_compute_kernel_target
+
+
+filterwarnings('default', message='\'numba\'', category=ImportWarning, module='densratio')
+__all__ = ['densratio', 'set_compute_kernel_target']

--- a/densratio/helpers.py
+++ b/densratio/helpers.py
@@ -1,6 +1,22 @@
 # -*- coding: utf-8 -*-
 
-from numpy import array, matrix, ndarray
+from numpy import array, matrix, ndarray, result_type
+
+
+np_float = result_type(float)
+try:
+    import numba as nb
+except ModuleNotFoundError:
+    guvectorize_compute = None
+else:
+    _nb_float = nb.from_dtype(np_float)
+
+    def guvectorize_compute(target: str, *, cache: bool = True):
+        return nb.guvectorize([nb.void(_nb_float[:, :], _nb_float[:], _nb_float, _nb_float[:])],
+                              '(m, p),(p),()->(m)',
+                              nopython=True,
+                              target=target,
+                              cache=cache)
 
 
 def is_numeric(x):


### PR DESCRIPTION
`densratio.RuLSIF.compute_kernel_Gaussian` has been updated with a performance-improved implementation. [The sheet](https://github.com/hoxo-m/densratio_py/files/5016129/performance.sheet.pdf) comparing the baseline (original) and performance-improved implementations is also available at [https://bit.ly/densratio_performance](https://bit.ly/densratio_performance); I hope it is pretty self-explanatory.

The `densratio.RuLSIF.set_compute_kernel_target` (also available to be imported directly from `densratio`) accepts one of the following string arguments, and sets the underlying _engine_ to carry out calculations:
- `numpy` - [numpy broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html#module-numpy.doc.broadcasting) optimized. It must be noted the underlying BLAS library (e.g. Intel's MKL) can take advantage of [multi threading model](https://software.intel.com/content/www/us/en/develop/documentation/mkl-linux-developer-guide/top/managing-performance-and-memory/improving-performance-with-threading/using-additional-threading-control.html).
- `cpu` - [numba generalized universal function single thread](https://numba.pydata.org/numba-doc/latest/user/vectorize.html#the-guvectorize-decorator) optimized.
- `parallel` - [numba generalized universal function multi thread](https://numba.pydata.org/numba-doc/latest/reference/jit-compilation.html#numba.guvectorize) optimized. Please be advised all [threading layer specifics](https://numba.pydata.org/numba-doc/latest/user/threading-layer.html) apply.

Due to aforementioned multi threading technicalities, the `engine` defaults to `cpu` when `numba` is available, or `numpy` otherwise. I do not think adding the `numba` requirement is the best idea, as it can potentially be not backward compatible with other existing projects already dependent on `densratio`. 
The performance-improved `densratio.RuLSIF.set_compute_kernel_target` implementation returns a `numpy.matrix` if any of the first two arguments is of the `numpy.matrix` type. Or it returns and expects a `numpy.ndarray`, in case future commits replace the deprecated `numpy.matrix` with just `numpy.ndarray`.