### PR TITLE
Matrix to ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ gives the following output:
     #>   Kernel type: Gaussian
     #>   Number of kernels: 100
     #>   Bandwidth(sigma): 0.1
-    #>   Centers: matrix([[-0.09591373],..
+    #>   Centers: array([[-0.09591373],..
     #> 
     #> Kernel Weights (theta):
     #>   array([0.04990797, 0.0550548 , 0.04784736, 0.04951904, 0.04840418,..
@@ -189,7 +189,7 @@ compute the alpha-relative density ratio at the passed coordinates.
     #>   Kernel type: Gaussian
     #>   Number of kernels: 100
     #>   Bandwidth(sigma): 0.1
-    #>   Centers: matrix([[0.92113356],..
+    #>   Centers: array([[0.92113356],..
     #> 
     #> Kernel Weights (theta):
     #>   array([0.08848922, 0.03377533, 0.0753727 , 0.06141277, 0.02543963,..
@@ -254,7 +254,7 @@ gives the following output:
     #>   Kernel type: Gaussian
     #>   Number of kernels: 100
     #>   Bandwidth(sigma): 0.3
-    #>   Centers: matrix([[1.01477443, 1.38864061],..
+    #>   Centers: array([[1.01477443, 1.38864061],..
     #> 
     #> Kernel Weights (theta):
     #>   array([0.06151164, 0.08012094, 0.10467369, 0.13868176, 0.14917063,..
@@ -290,15 +290,15 @@ levels = [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4.5]
 plt.figure(figsize=(10, 4))
 plt.subplot(1, 2, 1)
 plt.contourf(range_, range_, true_alpha_density_ratio(grid).reshape(200, 200), levels)
-#> <matplotlib.contour.QuadContourSet object at 0x000001C0C05E5870>
+#> <matplotlib.contour.QuadContourSet object at 0x0000022E950202E0>
 plt.colorbar()
-#> <matplotlib.colorbar.Colorbar object at 0x000001C0C0607010>
+#> <matplotlib.colorbar.Colorbar object at 0x0000022E9500DA80>
 plt.title("True Alpha-Relative Density Ratio")
 plt.subplot(1, 2, 2)
 plt.contourf(range_, range_, estimated_alpha_density_ratio(grid).reshape(200, 200), levels)
-#> <matplotlib.contour.QuadContourSet object at 0x000001C0C0541690>
+#> <matplotlib.contour.QuadContourSet object at 0x0000022E942C8EE0>
 plt.colorbar()
-#> <matplotlib.colorbar.Colorbar object at 0x000001C0C1352FE0>
+#> <matplotlib.colorbar.Colorbar object at 0x0000022E95095150>
 plt.title("Estimated Alpha-Relative Density Ratio")
 plt.show()
 ```

--- a/densratio/core.py
+++ b/densratio/core.py
@@ -9,7 +9,7 @@ Estimate Density Ratio p(x)/q(y)
 
 from numpy import linspace
 from .RuLSIF import RuLSIF
-from .helpers import to_numpy_matrix
+from .helpers import to_ndarray
 
 
 def densratio(x, y, alpha=0, sigma_range="auto", lambda_range="auto", kernel_num=100, verbose=True):
@@ -45,8 +45,8 @@ def densratio(x, y, alpha=0, sigma_range="auto", lambda_range="auto", kernel_num
       >>> print(density_ratio)
     """
 
-    x = to_numpy_matrix(x)
-    y = to_numpy_matrix(y)
+    x = to_ndarray(x)
+    y = to_ndarray(y)
 
     if x.shape[1] != y.shape[1]:
         raise ValueError("x and y must be same dimensions.")

--- a/densratio/helpers.py
+++ b/densratio/helpers.py
@@ -23,17 +23,15 @@ def is_numeric(x):
     return isinstance(x, int) or isinstance(x, float)
 
 
-def to_numpy_matrix(x):
-    if isinstance(x, matrix):
-        return x
-    elif isinstance(x, ndarray):
+def to_ndarray(x):
+    if isinstance(x, ndarray):
         if len(x.shape) == 1:
-            return matrix(x).T
+            return x.reshape(-1, 1)
         else:
-            return matrix(x)
+            return x
     elif str(type(x)) == "<class 'pandas.core.frame.DataFrame'>":
-        return x.as_matrix()
+        return x.values
     elif not x:
         raise ValueError("Cannot transform to numpy.matrix.")
     else:
-        return to_numpy_matrix(array(x))
+        return to_ndarray(array(x))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,35 +18,35 @@ class BasicTestSuite(unittest.TestCase):
         self.assertTrue(helpers.is_numeric(y))
         self.assertFalse(helpers.is_numeric(z))
 
-    def test_to_numpy_matrix_list(self):
+    def test_to_ndarray_list(self):
         x = [1,2,3]
-        x = helpers.to_numpy_matrix(x)
-        assert_array_equal(x, matrix([1,2,3]).T)
+        x = helpers.to_ndarray(x)
+        assert_array_equal(x, array([1,2,3]).reshape(-1, 1))
 
-    def test_to_numpy_matrix_list2(self):
+    def test_to_ndarray_list2(self):
         x = [[1,2],[3,4]]
-        x = helpers.to_numpy_matrix(x)
-        assert_array_equal(x, matrix([[1,2],[3,4]]))
+        x = helpers.to_ndarray(x)
+        assert_array_equal(x, array([[1,2],[3,4]]))
 
-    def test_to_numpy_matrix_ndarray(self):
+    def test_to_ndarray_ndarray(self):
         x = array([1,2,3])
-        x = helpers.to_numpy_matrix(x)
-        assert_array_equal(x, matrix([1,2,3]).T)
+        x = helpers.to_ndarray(x)
+        assert_array_equal(x, array([1,2,3]).reshape(-1, 1))
 
-    def test_to_numpy_matrix_ndarray2(self):
+    def test_to_ndarray_ndarray2(self):
         x = array([[1,2],[3,4]])
-        x = helpers.to_numpy_matrix(x)
-        assert_array_equal(x, matrix([[1,2],[3,4]]))
+        x = helpers.to_ndarray(x)
+        assert_array_equal(x, array([[1,2],[3,4]]))
 
-    def test_to_numpy_matrix_matrix(self):
-        x = matrix([[1,2],[3,4]])
-        x = helpers.to_numpy_matrix(x)
-        assert_array_equal(x, matrix([[1,2],[3,4]]))
+    # def test_to_ndarray_matrix(self):
+    #     x = matrix([[1,2],[3,4]])
+    #     x = helpers.to_ndarray(x)
+    #     assert_array_equal(x, array([[1,2],[3,4]]))
 
-    def test_to_numpy_matrix_pandas_DataFrame(self):
+    def test_to_ndarray_pandas_DataFrame(self):
         x = DataFrame([[1,2],[3,4]])
-        x = helpers.to_numpy_matrix(x)
-        assert_array_equal(x, matrix([[1,2],[3,4]]))
+        x = helpers.to_ndarray(x)
+        assert_array_equal(x, array([[1,2],[3,4]]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
numpy.matrix is deprecated. use ndarray

Source:
https://stackoverflow.com/questions/53254738/deprecation-status-of-the-numpy-matrix-class/53254739#53254739

For Japanese:
https://qiita.com/kaityo256/items/2320282ceff389d95ac8