### PR TITLE
Alpha normalize: [0, 1] linear transformation of density ratio to [alpha, 1] range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,26 @@ plt.show()
 
 ![](README_files/figure-gfm/compare-2d-5.png)<!-- -->
 
-## 5. References
+## 5. `DensityRatio.alpha_normalize` function
+This is a supplementary function, that by applying the following linear transformation changes the lower `0` bound (infimum) of its `values` argument in the range of `[0, 1]` to `[alpha, 1]` :
+```math
+x' = (1 - alpha) * x + alpha =  x + alpha * (1 - x)
+```
+The function returns an array whose values are elements of the `[alpha, alpha^-1]` bounded set; the upper `alpha^-1` bound (supremum) is due to properties of the alpha-relative density ratio estimator. As long as the outcome is comprised of positive values only, when the `densratio_obj.alpha_normalize` function is applied to the `densratio_obj.compute_density_ratio` result, it renders the density ratio estimation eligible to be further processed on the logarithmic scale. 
+
+### 5.1. Implementation specifics
+To preserve vital estimator properties, there are 2 invariants always met by the function results:
+1. The number of unique values must not changed.
+2. The order of output values remains the same as in the input argument (as determined by [`numpy.argsort`](https://numpy.org/doc/stable/reference/generated/numpy.argsort.html)).
+
+Due to floating‑point arithmetic, if two consecutive input numbers that are not equal are to be transformed to the same outcome, in order to satisfy the constraints in the list above and yield different values as well, the [`numpy.nextafter`](https://numpy.org/doc/stable/reference/generated/numpy.nextafter.html) is employed in the direction of `0`.  
+By virtue of this implementation approach, in extreme cases there is a possibility of output values that:
+- are less than `alpha`, or
+- are nonpositive.
+
+Should it happen, a relevant warning is issued.
+
+## 6. References
 
 \[1\] Hido, S., Tsuboi, Y., Kashima, H., Sugiyama, M., & Kanamori, T.
 **Statistical outlier detection using direct density ratio estimation.**
@@ -322,7 +341,7 @@ in Machine Learning.** Cambridge University Press 2012.
 Detection in Time-Series Data by Relative Density-Ratio Estimation**
 Neural Networks, 2013.
 
-## 6. Related Work
+## 7. Related Work
 
 -   densratio for R <https://github.com/hoxo-m/densratio>
 -   pykliep <https://github.com/srome/pykliep>

--- a/README.rmd
+++ b/README.rmd
@@ -251,7 +251,26 @@ plt.title("Estimated Alpha-Relative Density Ratio")
 plt.show()
 ```
 
-## 5. References
+## 5. `DensityRatio.alpha_normalize` function
+This is a supplementary function, that by applying the following linear transformation changes the lower `0` bound (infimum) of its `values` argument in the range of `[0, 1]` to `[alpha, 1]` :
+```math
+x' = (1 - alpha) * x + alpha =  x + alpha * (1 - x)
+```
+The function returns an array whose values are elements of the `[alpha, alpha^-1]` bounded set; the upper `alpha^-1` bound (supremum) is due to properties of the alpha-relative density ratio estimator. As long as the outcome is comprised of positive values only, when the `densratio_obj.alpha_normalize` function is applied to the `densratio_obj.compute_density_ratio` result, it renders the density ratio estimation eligible to be further processed on the logarithmic scale.
+
+### 5.1. Implementation specifics
+To preserve vital estimator properties, there are 2 invariants always met by the function results:
+1. The number of unique values must not changed.
+2. The order of output values remains the same as in the input argument (as determined by [`numpy.argsort`](https://numpy.org/doc/stable/reference/generated/numpy.argsort.html)).
+
+Due to floating‑point arithmetic, if two consecutive input numbers that are not equal are to be transformed to the same outcome, in order to satisfy the constraints in the list above and yield different values as well, the [`numpy.nextafter`](https://numpy.org/doc/stable/reference/generated/numpy.nextafter.html) is employed in the direction of `0`.
+By virtue of this implementation approach, in extreme cases there is a possibility of output values that:
+- are less than `alpha`, or
+- are nonpositive.
+
+Should it happen, a relevant warning is issued.
+
+## 6. References
 
 [1] Hido, S., Tsuboi, Y., Kashima, H., Sugiyama, M., & Kanamori, T.
 **Statistical outlier detection using direct density ratio estimation.**
@@ -268,7 +287,7 @@ Cambridge University Press 2012.
 **Change-Point Detection in Time-Series Data by Relative Density-Ratio Estimation**
 Neural Networks, 2013.
 
-## 6. Related Work
+## 7. Related Work
 
 - densratio for R https://github.com/hoxo-m/densratio
 - pykliep https://github.com/srome/pykliep

--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -132,7 +132,7 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
 
         # Compute the alpha-relative KL-divergence.
         n = x.shape[0]
-        divergence = log(g_x).sum(axis=0) / n if g_x.all() else '[not calculated]'
+        divergence = log(g_x).sum(axis=0) / n if (g_x > 0.).all() else '[not calculated]'
         return divergence
 
     alpha_PE = alpha_PE_divergence(x, y)

--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -140,7 +140,8 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
 
     if verbose:
         print("Approximate alpha-relative PE-divergence = {:03.2f}".format(alpha_PE))
-        print("Approximate alpha-relative KL-divergence = {:03.2f}".format(alpha_KL))
+        alpha_KL_format = '{}' if isinstance(alpha_KL, str) else '{:03.2f}'
+        print("Approximate alpha-relative KL-divergence =", alpha_KL_format.format(alpha_KL))
 
     kernel_info = KernelInfo(kernel_type="Gaussian", kernel_num=kernel_num, sigma=sigma, centers=centers)
     result = DensityRatio(method="RuLSIF", alpha=alpha, theta=theta, lambda_=lambda_, alpha_PE=alpha_PE, alpha_KL=alpha_KL,

--- a/densratio/__init__.py
+++ b/densratio/__init__.py
@@ -1,7 +1,8 @@
 from warnings import filterwarnings
 from .core import densratio
+from .helpers import alpha_normalize
 from .RuLSIF import set_compute_kernel_target
 
 
 filterwarnings('default', message='\'numba\'', category=ImportWarning, module='densratio')
-__all__ = ['densratio', 'set_compute_kernel_target']
+__all__ = ['alpha_normalize', 'densratio', 'set_compute_kernel_target']

--- a/densratio/__init__.py
+++ b/densratio/__init__.py
@@ -5,4 +5,5 @@ from .RuLSIF import set_compute_kernel_target
 
 
 filterwarnings('default', message='\'numba\'', category=ImportWarning, module='densratio')
+filterwarnings('always', message='Normalized vector contains', category=RuntimeWarning, module=r'densratio\.helpers')
 __all__ = ['alpha_normalize', 'densratio', 'set_compute_kernel_target']

--- a/densratio/density_ratio.py
+++ b/densratio/density_ratio.py
@@ -4,7 +4,7 @@ from re import sub
 
 class DensityRatio:
     """Density Ratio."""
-    def __init__(self, method, alpha, theta, lambda_, alpha_PE, alpha_KL, kernel_info, compute_density_ratio):
+    def __init__(self, method, alpha, theta, lambda_, alpha_PE, alpha_KL, kernel_info, compute_density_ratio, alpha_normalize):
         self.method = method
         self.alpha = alpha
         self.theta = theta
@@ -13,6 +13,7 @@ class DensityRatio:
         self.alpha_KL = alpha_KL
         self.kernel_info = kernel_info
         self.compute_density_ratio = compute_density_ratio
+        self.alpha_normalize = alpha_normalize
 
     def __str__(self):
         return """

--- a/densratio/helpers.py
+++ b/densratio/helpers.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from numpy import array, matrix, ndarray, result_type
+from warnings import warn
 
 
 np_float = result_type(float)
@@ -33,3 +36,50 @@ def to_ndarray(x):
         raise ValueError("Cannot transform to numpy.matrix.")
     else:
         return to_ndarray(array(x))
+
+
+def alpha_normalize(values: ndarray, alpha: float) -> ndarray:
+    """
+    Normalizes values less than 1 so the minimum value to replace 0 is symmetrical to alpha^-1
+    with respect to the natural logarithm.
+
+    Arguments:
+        values (numpy.array): A vector to normalize.
+        alpha (float): The normalization term.
+
+    Returns:
+        Normalized numpy.array object that preserves the order and the number of unique input argument values.
+    """
+    if not alpha:
+        return values
+
+    a = 1. - alpha
+    last_value = 1.
+    inserted = last_value
+    outcome = np.empty(values.shape, dtype=values.dtype)
+
+    values_argsort = np.argsort(values)
+    for i in np.flip(values_argsort):
+        value = values[i]
+        if value >= 1.:
+            outcome[i] = value
+            continue
+
+        if value < last_value:
+            new_value = inserted - a * (last_value - value)
+            inserted = np.nextafter(inserted, 0) if new_value == inserted else new_value
+            last_value = value
+        else:
+            assert value == last_value
+
+        outcome[i] = inserted
+
+    if inserted < alpha:
+        warn(f'Normalized vector contains at least one value [min={inserted}] less than alpha [{alpha}].',
+             RuntimeWarning)
+    if not outcome.all():
+        warn('Normalized vector contains some zero values.', RuntimeWarning)
+
+    assert np.unique(values).size == np.unique(outcome).size
+    assert (values_argsort == np.argsort(outcome)).all()
+    return outcome

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,10 +1,13 @@
 import unittest
 
+import numpy as np
 from numpy import array, matrix
 from numpy.testing import assert_array_equal
 from pandas import DataFrame
 from .context import helpers
 
+
+# noinspection PyMethodMayBeStatic
 class BasicTestSuite(unittest.TestCase):
     """Tests for Helper Functions."""
 
@@ -45,6 +48,52 @@ class BasicTestSuite(unittest.TestCase):
         x = DataFrame([[1,2],[3,4]])
         x = helpers.to_ndarray(x)
         assert_array_equal(x, array([[1,2],[3,4]]))
+
+    def test_alpha_normalize_0d_input(self):
+        with self.assertRaises(ValueError):
+            helpers.alpha_normalize(np.array(None), 1E-3)
+
+    def test_alpha_normalize_2d_input(self):
+        with self.assertRaises(ValueError):
+            helpers.alpha_normalize(np.arange(4).reshape(2, -1), 1E-3)
+
+    def test_alpha_normalize_zero_alpha(self):
+        values = np.random.rand(5)
+        assert_array_equal(values, helpers.alpha_normalize(values, 0))
+
+    def test_alpha_normalize_negative_alpha(self):
+        values = np.random.rand(5)
+        with self.assertWarns(RuntimeWarning):
+            assert_array_equal(values, helpers.alpha_normalize(values, -1E-3))
+
+    def test_alpha_normalize_lower_changed(self):
+        alpha = .05
+        lower, upper = np.arange(0, 1, alpha), np.arange(1, 21)
+        normalized_values = helpers.alpha_normalize(np.concatenate((lower, upper)), alpha)
+        self.assertRaises(AssertionError, assert_array_equal, lower, normalized_values[:lower.size])
+        assert_array_equal(upper, normalized_values[-upper.size:])
+
+    def test_alpha_normalize_equal_unique_count(self):
+        alpha = .05
+        values = np.concatenate((np.arange(0, 1, alpha), np.arange(1, 21)))
+        normalized_values = helpers.alpha_normalize(values, alpha)
+        self.assertEqual(np.unique(values).size, np.unique(normalized_values).size)
+
+    def test_alpha_normalize_same_argsort(self):
+        alpha = .05
+        values = np.concatenate((np.arange(0, 1, alpha), np.arange(1, 21)))
+        np.random.shuffle(values)
+        normalized_values = helpers.alpha_normalize(values, alpha)
+        self.assertTrue((np.argsort(values) == np.argsort(normalized_values)).all())
+
+    def test_alpha_normalize_alpha_warning(self):
+        values = np.array([0, np.nextafter(0, 1), 1])
+        self.assertWarns(RuntimeWarning, helpers.alpha_normalize, values, .5)
+
+    def test_alpha_normalize_nonpositive_warning(self):
+        values = np.array([0, np.nextafter(0, 1), 1])
+        self.assertWarns(RuntimeWarning, helpers.alpha_normalize, values, values[1])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Synopsis
The pull request introduces a new function: [`helpers.alpha_normalize(values: ndarray, alpha: float) -> ndarray`](https://github.com/hoxo-m/densratio_py/blob/a9228d961bd83af7473419d992305ee9fe627e2a/densratio/helpers.py#L41) that changes the lower `0` bound (infimum) of the input `values` argument in the range of `[0, 1]` to `[alpha, 1]` by applying a _nearly_$^1$ linear transformation.
# Rationale
There are many possible scenarios where the estimated density ratio is further process on the **logarithmic scale**, such as increasing numerical stability by replacing a product of conditionally independent variates with their sum, or a quotient with the difference, or for the sake of clarity when plotting respective probability density functions. Alpha-relative density ratio estimator yields results in the `[0, alpha^-1]` boundary,  and as long as `0` is not in the logarithmic domain, it must be handled prior to applying the logarithmic transformation. The `alpha_normalize` function does exactly that by applying the following linear transformation to input values in the range of `[0, 1]`:
```math
x' = (1 - alpha) * x + alpha =  x + alpha * (1 - x)
```
where `alpha` is the _normalization term_, a small real number (technically rational, because it is implemented as a floating point number).

The `[0, 1]` range where the function is applied has been selected to modify the estimated density ration as little as possible, especially so the upper `alpha^-1` supremum is not changed, as it would contravene the properties of alpha-relative density ratio estimator. Additionally, `log(1)=0` on the logarithmic scale might attribute specific qualities in case of some models (Probabilistic Record Linkage, for instance), hence input `values` are not modified in (and beyond) this point.
## Implementation specifics
To preserve vital estimator properties, there are 2 invariants always met by the function results:
1. The number of unique values must not changed.
2. The order of output values remains the same as in the input argument (as determined by [`numpy.argsort`](https://numpy.org/doc/stable/reference/generated/numpy.argsort.html)).

$^1$ These invariants account for the _nearly_ linear transformation. Due to floating‑point arithmetic, if two consecutive input numbers that are not equal are to be transformed to the same outcome, in order to satisfy the constraints in the list above and yield different values as well, the [`numpy.nextafter`](https://numpy.org/doc/stable/reference/generated/numpy.nextafter.html) is employed in the direction of `0`.  
By virtue of this implementation approach, in extreme cases there is a possibility of output values that:
- are less than `alpha`, or
- are nonpositive.

Should it happen, a relevant warning is issued.
## [`DensityRatio.alpha_normalize`](https://github.com/hoxo-m/densratio_py/blob/a9228d961bd83af7473419d992305ee9fe627e2a/densratio/RuLSIF.py#L91) function
The function simply calls [`helpers.alpha_normalize`](https://github.com/hoxo-m/densratio_py/blob/a9228d961bd83af7473419d992305ee9fe627e2a/densratio/helpers.py#L41) passing its [`alpha`](https://github.com/hoxo-m/densratio_py/blob/a9228d961bd83af7473419d992305ee9fe627e2a/densratio/density_ratio.py#L9) field value as the second argument (_normalization term_). It leads to the `[alpha, alpha^-1]` boundary of the estimated density ratio values, which transforms to `[log(alpha), -log(alpha)]` on the logarithmic scale, with `log(1)=0` being exactly in the middle. Such range can render some probability density graphs (e.g. Fellegi Sunter log likelihood) really lucid and comprehensible.
# Closing remarks
Both `alpha_normalize` functions are supplementary and optional, users can do without them and stick to the raw `compute_density_ratio` outcome. The only place the `alpha_normalize` function has been introduce in the original code flow is the `alpha_KL_divergence` function. Because the divergence numerator makes use of [`numpy.log`](https://numpy.org/doc/stable/reference/generated/numpy.log.html), should `0` occur in the estimated density ratio, the invalid `-inf` Kullback–Leibler divergence value is returned.
