### PR TITLE
Kernel centres semi-stratified selection without replacement

### DIFF
--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -10,12 +10,11 @@ References:
         Journal of Machine Learning Research 10 (2009) 1391-1445.
 """
 
-from numpy import array, asarray, asmatrix, diag, diagflat, empty, exp, inf, log, matrix, multiply, ones, power, sum
-from numpy.random import randint
+from numpy import array, asarray, asmatrix, diag, diagflat, empty, exp, inf, log, matrix, multiply, ones, power, ravel, sum
 from numpy.linalg import solve
 from warnings import warn
 from .density_ratio import DensityRatio, KernelInfo
-from .helpers import guvectorize_compute, np_float, to_ndarray
+from .helpers import guvectorize_compute, np_float, semi_stratified_sample, to_ndarray
 
 
 def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True):
@@ -46,7 +45,8 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
     kernel_num = min(kernel_num, nx)
 
     # Randomly take a subset of x, to identify centers for the kernels.
-    centers = x[randint(nx, size=kernel_num)]
+    x_array = (ravel if 1 == x.shape[1] else asarray)(x)
+    centers = x[semi_stratified_sample(x_array, kernel_num)]
 
     if verbose:
         print("RuLSIF starting...")

--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -45,8 +45,7 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
     kernel_num = min(kernel_num, nx)
 
     # Randomly take a subset of x, to identify centers for the kernels.
-    x_array = (ravel if 1 == x.shape[1] else asarray)(x)
-    centers = x[semi_stratified_sample(x_array, kernel_num)]
+    centers = x[semi_stratified_sample(ravel(x) if 1 == x.shape[1] else x, size=kernel_num)]
 
     if verbose:
         print("RuLSIF starting...")

--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -10,7 +10,7 @@ References:
         Journal of Machine Learning Research 10 (2009) 1391-1445.
 """
 
-from numpy import array, asarray, asmatrix, diag, diagflat, empty, exp, inf, log, matrix, multiply, ones, power, ravel, sum
+from numpy import array, asarray, asmatrix, diag, diagflat, empty, exp, inf, log, matrix, multiply, ones, power, sum
 from numpy.linalg import solve
 from warnings import warn
 from .density_ratio import DensityRatio, KernelInfo
@@ -45,7 +45,7 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
     kernel_num = min(kernel_num, nx)
 
     # Randomly take a subset of x, to identify centers for the kernels.
-    centers = x[semi_stratified_sample(ravel(x) if 1 == x.shape[1] else x, size=kernel_num)]
+    centers = x[semi_stratified_sample(x, size=kernel_num)]
 
     if verbose:
         print("RuLSIF starting...")

--- a/densratio/helpers.py
+++ b/densratio/helpers.py
@@ -37,28 +37,28 @@ def to_ndarray(x):
         return to_ndarray(array(x))
 
 
-def semi_stratified_sample(data: ndarray, samples: int) -> ndarray:
+def semi_stratified_sample(data: ndarray, size: int) -> ndarray:
     ndims = data.ndim
     if ndims > 2:
         raise ValueError('Only single and 2d arrays are supported.')
-    if not samples:
+    if not size:
         return np.empty(0)
 
     data_length = data.shape[0]
     result = np.arange(data_length, dtype=int)
-    if samples == data_length:
+    if size == data_length:
         np.random.shuffle(result)
         return result
-    if samples < 0:
-        raise ValueError('Number of samples must be a non-negative integer number.')
-    if samples > data_length:
-        raise ValueError('Number of samples cannot exceed the shape of input data.')
+    if size < 0:
+        raise ValueError('Sample size must be a non-negative integer number.')
+    if size > data_length:
+        raise ValueError('Sample size cannot exceed the shape of input data.')
 
     dims = data.shape[1] if 2 == ndims else 1
     indexed = np.column_stack((data, result))
     result = np.empty(0, dtype=indexed.dtype)
 
-    samples_no = samples // dims
+    samples_no = size // dims
     if samples_no:
         percentiles = np.linspace(0., 100., num=samples_no, endpoint=False)[1:]
 
@@ -88,6 +88,6 @@ def semi_stratified_sample(data: ndarray, samples: int) -> ndarray:
 
     result = np.append(
         result,
-        np.random.choice(indexed[..., dims], size=samples-result.size, replace=False)).astype(int)
+        np.random.choice(indexed[..., dims], size=size - result.size, replace=False)).astype(int)
     np.random.shuffle(result)
     return result

--- a/densratio/helpers.py
+++ b/densratio/helpers.py
@@ -38,8 +38,7 @@ def to_ndarray(x):
 
 
 def semi_stratified_sample(data: ndarray, size: int) -> ndarray:
-    ndims = data.ndim
-    if ndims > 2:
+    if data.ndim > 2:
         raise ValueError('Only single and 2d arrays are supported.')
     if not size:
         return np.empty(0)
@@ -54,7 +53,7 @@ def semi_stratified_sample(data: ndarray, size: int) -> ndarray:
     if size > data_length:
         raise ValueError('Sample size cannot exceed the shape of input data.')
 
-    dims = data.shape[1] if 2 == ndims else 1
+    dims = data.shape[1]
     indexed = np.column_stack((data, result))
     result = np.empty(0, dtype=indexed.dtype)
 

--- a/densratio/helpers.py
+++ b/densratio/helpers.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from numpy import array, matrix, ndarray, result_type
 
 
@@ -33,3 +35,59 @@ def to_ndarray(x):
         raise ValueError("Cannot transform to numpy.matrix.")
     else:
         return to_ndarray(array(x))
+
+
+def semi_stratified_sample(data: ndarray, samples: int) -> ndarray:
+    ndims = data.ndim
+    if ndims > 2:
+        raise ValueError('Only single and 2d arrays are supported.')
+    if not samples:
+        return np.empty(0)
+
+    data_length = data.shape[0]
+    result = np.arange(data_length, dtype=int)
+    if samples == data_length:
+        np.random.shuffle(result)
+        return result
+    if samples < 0:
+        raise ValueError('Number of samples must be a non-negative integer number.')
+    if samples > data_length:
+        raise ValueError('Number of samples cannot exceed the shape of input data.')
+
+    dims = data.shape[1] if 2 == ndims else 1
+    indexed = np.column_stack((data, result))
+    result = np.empty(0, dtype=indexed.dtype)
+
+    samples_no = samples // dims
+    if samples_no:
+        percentiles = np.linspace(0., 100., num=samples_no, endpoint=False)[1:]
+
+        for d in range(dims):
+            column = indexed[..., d]
+            quantiles = np.append(column.min(), np.percentile(column, percentiles))
+            indices = []
+            i, sample_size = 0, 1
+
+            while i < samples_no:
+                left = quantiles[i]
+                i += 1
+                right = np.Inf if i == samples_no else quantiles[i]
+                try:
+                    indices.extend(np.random.choice(
+                        indexed[(left <= column) & (column < right), dims],
+                        size=sample_size,
+                        replace=False))
+                except ValueError:
+                    sample_size += 1
+                    continue
+                else:
+                    sample_size = 1
+
+            indexed = indexed[~np.isin(indexed[:, dims], indices)]
+            result = np.append(result, indices)
+
+    result = np.append(
+        result,
+        np.random.choice(indexed[..., dims], size=samples-result.size, replace=False)).astype(int)
+    np.random.shuffle(result)
+    return result


### PR DESCRIPTION
The pull request revises the way kernel centres are selected. The following changes have been introduced:
- [np.random.choice](https://numpy.org/doc/stable/reference/random/generated/numpy.random.choice.html) to sample input data without replacement;
- [np.percentile](https://numpy.org/doc/stable/reference/generated/numpy.percentile.html) so samples are stratified with respect to (possibly multivariate) `x` values.

I call this manner of centre selection **semi**-stratified, because the final result is concatenated independently from every column of the second array dimension, where indices are chosen randomly from quantiles returned by [np.percentile](https://numpy.org/doc/stable/reference/generated/numpy.percentile.html).

Resolves the following issues:
- fixes #12 - sample without replacement.
- fixes #13 - increases result _stability_, as confirmed by the original poster.