### PR TITLE
[codex] Fix RuLSIF center sampling and 2D test

### DIFF
--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -11,7 +11,7 @@ References:
 """
 
 from numpy import array, asarray, asmatrix, diag, diagflat, empty, exp, inf, log, matrix, multiply, ones, power, sum
-from numpy.random import randint
+from numpy.random import choice
 from numpy.linalg import solve
 from warnings import warn
 from .density_ratio import DensityRatio, KernelInfo
@@ -46,7 +46,7 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
     kernel_num = min(kernel_num, nx)
 
     # Randomly take a subset of x, to identify centers for the kernels.
-    centers = x[randint(nx, size=kernel_num)]
+    centers = x[choice(nx, size=kernel_num, replace=False)]
 
     if verbose:
         print("RuLSIF starting...")

--- a/tests/test_RuLSIF.py
+++ b/tests/test_RuLSIF.py
@@ -1,7 +1,8 @@
 import unittest
 
 from scipy.stats import norm, multivariate_normal
-from numpy import linspace
+from numpy import linspace, mgrid, unique
+from numpy.random import seed
 from .context import densratio
 
 
@@ -45,8 +46,19 @@ class BasicTestSuite(unittest.TestCase):
         y = multivariate_normal.rvs(size=300, mean=[1, 1], cov=[[1./2, 0], [0, 2]], random_state=71)
         result = densratio(x, y, alpha=0.5)
         self.assertIsNotNone(result)
-        density_ratio = result.compute_density_ratio(linspace(-1, 3))
+        space_range = slice(-1, 3, 50j)
+        space_2d = mgrid[space_range, space_range].reshape(2, -1).T
+        density_ratio = result.compute_density_ratio(space_2d)
         self.assertTrue((density_ratio >= 0).all())
+
+    def test_kernel_centers_are_selected_without_replacement(self):
+        x = linspace(0, 1, 20)
+        y = linspace(0.1, 1.1, 20)
+        seed(71)
+        result = densratio(x, y, sigma_range=[0.1], lambda_range=[0.1], kernel_num=20, verbose=False)
+        centers = result.kernel_info.centers
+
+        self.assertEqual(unique(centers).size, centers.shape[0])
 
     def test_densratio_dimension_error(self):
         x = norm.rvs(size=200, loc=0, scale=1./8, random_state=71)


### PR DESCRIPTION
## Summary

- Select RuLSIF kernel centers without replacement, matching the R package behavior and addressing #12.
- Fix the 2D RuLSIF test to pass 2D query points instead of a 1D linspace, addressing #17.
- Add a regression test that verifies kernel centers are selected without replacement.

## Validation

- python -m unittest tests.test_RuLSIF.BasicTestSuite.test_kernel_centers_are_selected_without_replacement
- python -m unittest tests.test_RuLSIF.BasicTestSuite.test_alphadensratio_2d
- python -m unittest tests.test_r_compatibility

Note: test_alphadensratio_2d takes about 140 seconds locally because it uses the existing auto grid-search path.