### PR TITLE
[codex] Make DensityRatio picklable

### DIFF
--- a/densratio/RuLSIF.py
+++ b/densratio/RuLSIF.py
@@ -128,7 +128,7 @@ def RuLSIF(x, y, alpha, sigma_range, lambda_range, kernel_num=100, verbose=True)
 
     kernel_info = KernelInfo(kernel_type="Gaussian", kernel_num=kernel_num, sigma=sigma, centers=centers)
     result = DensityRatio(method="RuLSIF", alpha=alpha, theta=theta, lambda_=lambda_, alpha_PE=alpha_PE, alpha_KL=alpha_KL,
-                          kernel_info=kernel_info, compute_density_ratio=alpha_density_ratio)
+                          kernel_info=kernel_info)
 
     if verbose:
         print("RuLSIF completed.")

--- a/densratio/density_ratio.py
+++ b/densratio/density_ratio.py
@@ -4,7 +4,7 @@ from re import sub
 
 class DensityRatio:
     """Density Ratio."""
-    def __init__(self, method, alpha, theta, lambda_, alpha_PE, alpha_KL, kernel_info, compute_density_ratio):
+    def __init__(self, method, alpha, theta, lambda_, alpha_PE, alpha_KL, kernel_info, compute_density_ratio=None):
         self.method = method
         self.alpha = alpha
         self.theta = theta
@@ -12,7 +12,14 @@ class DensityRatio:
         self.alpha_PE = alpha_PE
         self.alpha_KL = alpha_KL
         self.kernel_info = kernel_info
-        self.compute_density_ratio = compute_density_ratio
+
+    def compute_density_ratio(self, x):
+        from .RuLSIF import compute_kernel_Gaussian
+        from .helpers import to_ndarray
+
+        x = to_ndarray(x)
+        phi_x = compute_kernel_Gaussian(x, self.kernel_info.centers, self.kernel_info.sigma)
+        return phi_x @ self.theta
 
     def __str__(self):
         return """

--- a/tests/test_r_compatibility.py
+++ b/tests/test_r_compatibility.py
@@ -1,4 +1,5 @@
 import importlib
+import pickle
 import unittest
 
 import numpy as np
@@ -70,6 +71,19 @@ class RCompatibilityTestSuite(unittest.TestCase):
         result = self.fit_rulsif()
 
         self.assert_density_ratio_for_new_input(result)
+
+    def test_density_ratio_object_round_trips_through_pickle(self):
+        result = self.fit_rulsif()
+        new_x = np.linspace(0, 2, 11)
+        expected_density_ratio = result.compute_density_ratio(new_x)
+
+        restored = pickle.loads(pickle.dumps(result))
+        actual_density_ratio = restored.compute_density_ratio(new_x)
+
+        self.assertEqual(restored.method, result.method)
+        self.assertEqual(restored.alpha, result.alpha)
+        self.assertEqual(restored.lambda_, result.lambda_)
+        np.testing.assert_allclose(actual_density_ratio, expected_density_ratio)
 
     def test_rulsif_multivariate_new_input_rows(self):
         rng = np.random.RandomState(314)


### PR DESCRIPTION
## Summary

- Move density-ratio evaluation onto the top-level DensityRatio class instead of storing a local RuLSIF closure on each result object.
- Keep RuLSIF result behavior the same by computing from stored theta, kernel centers, and sigma.
- Add a pickle round-trip regression test that verifies restored objects still compute the same density ratios.

Fixes #10.

## Validation

- python -m unittest tests.test_r_compatibility
- python -m unittest tests.test_RuLSIF.BasicTestSuite.test_kernel_centers_are_selected_without_replacement
- python -m unittest tests.test_helpers