### PR TITLE
[codex] Implement KLIEP

### DIFF
--- a/densratio/KLIEP.py
+++ b/densratio/KLIEP.py
@@ -1,0 +1,164 @@
+"""
+Kullback-Leibler Importance Estimation Procedure (KLIEP).
+"""
+
+from numbers import Number
+
+from numpy import arange, asarray, inf, log, mean, ones
+from numpy.random import choice, permutation
+
+from .RuLSIF import compute_kernel_Gaussian
+from .density_ratio import DensityRatio, KernelInfo
+
+
+def KLIEP(x, y, sigma="auto", kernel_num=100, fold=5, verbose=True):
+    nx = x.shape[0]
+    kernel_num = min(kernel_num, nx)
+    centers = x[choice(nx, size=kernel_num, replace=False)]
+
+    if verbose:
+        print("KLIEP starting...")
+
+    sigma = _select_sigma(x, y, centers, sigma, fold, verbose)
+
+    if verbose:
+        print("Optimizing kernel weights...")
+
+    phi_x = compute_kernel_Gaussian(x, centers, sigma)
+    phi_y = compute_kernel_Gaussian(y, centers, sigma)
+    kernel_weights = KLIEP_optimize_alpha(phi_x, phi_y)
+
+    kernel_info = KernelInfo(kernel_type="Gaussian", kernel_num=kernel_num, sigma=sigma, centers=centers)
+    result = DensityRatio(method="KLIEP", alpha=None, theta=kernel_weights, lambda_=None, alpha_PE=None,
+                          alpha_KL=None, kernel_info=kernel_info, fold=fold)
+
+    if verbose:
+        print("KLIEP completed.")
+
+    return result
+
+
+def _select_sigma(x, y, centers, sigma, fold, verbose):
+    if isinstance(sigma, str):
+        if sigma != "auto":
+            raise TypeError("Invalid value for sigma.")
+
+        if verbose:
+            print("Searching for the optimal sigma...")
+
+        sigma = KLIEP_search_sigma(x, y, centers, fold, verbose)
+
+        if verbose:
+            print("Found optimal sigma = {:.5f}.".format(sigma))
+
+        return sigma
+
+    if isinstance(sigma, Number):
+        return float(sigma)
+
+    sigma_range = asarray(sigma).ravel()
+    if sigma_range.size == 1:
+        return float(sigma_range[0])
+
+    if verbose:
+        print("Searching for the optimal sigma...")
+
+    sigma = KLIEP_search_sigma_list(x, y, centers, sigma_range, fold, verbose)
+
+    if verbose:
+        print("Found optimal sigma = {:.5f}.".format(sigma))
+
+    return sigma
+
+
+def KLIEP_search_sigma(x, y, centers, fold, verbose=True):
+    sigma = 10.0
+    score = -inf
+
+    for digit_position in range(0, -6, -1):
+        for _ in range(9):
+            sigma_new = sigma - 10.0 ** digit_position
+            score_new = KLIEP_compute_score_cv(sigma_new, x, y, centers, fold)
+            if score_new <= score:
+                break
+
+            score = score_new
+            sigma = sigma_new
+
+            if verbose:
+                print("  sigma = {:.5f}, score = {:.6f}".format(sigma, score))
+
+    return sigma
+
+
+def KLIEP_search_sigma_list(x, y, centers, sigma_list, fold, verbose=True):
+    sigma = None
+    score = -inf
+
+    for sigma_new in sigma_list:
+        score_new = KLIEP_compute_score_cv(sigma_new, x, y, centers, fold)
+        if score_new > score:
+            score = score_new
+            sigma = float(sigma_new)
+
+            if verbose:
+                print("  sigma = {:.5f}, score = {:.6f}".format(sigma, score))
+
+    return sigma
+
+
+def KLIEP_compute_score_cv(sigma, x, y, centers, fold):
+    phi_x = compute_kernel_Gaussian(x, centers, sigma)
+    phi_y = compute_kernel_Gaussian(y, centers, sigma)
+    mean_phi_y = phi_y.mean(axis=0)
+
+    nx = x.shape[0]
+    cv_split = permutation(nx) % fold
+
+    scores = []
+    for fold_index in range(fold):
+        alpha = KLIEP_optimize_alpha(phi_x[cv_split != fold_index, :], mean_phi_y=mean_phi_y)
+        scores.append(KLIEP_compute_score(phi_x[cv_split == fold_index, :], alpha))
+
+    return mean(scores)
+
+
+def KLIEP_optimize_alpha(phi_x, phi_y=None, mean_phi_y=None):
+    a = asarray(phi_x)
+    if phi_y is None:
+        if mean_phi_y is None:
+            raise ValueError("mean_phi_y must be provided when phi_y is omitted.")
+        b = asarray(mean_phi_y).ravel()
+    else:
+        b = asarray(phi_y).mean(axis=0).ravel()
+
+    c = b / (b @ b)
+    alpha = compute_next_alpha(ones(a.shape[1]), b, c)
+    score = KLIEP_compute_score(a, alpha)
+
+    for epsilon in 10.0 ** arange(3, -4, -1):
+        for _ in range(100):
+            alpha_new = alpha + epsilon * a.T @ (1 / (a @ alpha))
+            alpha_new = compute_next_alpha(alpha_new, b, c)
+            score_new = KLIEP_compute_score(a, alpha_new)
+
+            if score_new <= score:
+                break
+
+            alpha = alpha_new
+            score = score_new
+
+    return alpha
+
+
+def compute_next_alpha(alpha, b, c=None):
+    if c is None:
+        c = b / (b @ b)
+
+    alpha = alpha + (1 - b @ alpha) * c
+    alpha[alpha < 0] = 0
+    return alpha / (b @ alpha)
+
+
+def KLIEP_compute_score(phi, alpha):
+    return mean(log(phi @ alpha))

--- a/densratio/core.py
+++ b/densratio/core.py
@@ -6,6 +6,7 @@ Estimate Density Ratio p(x)/q(y)
 """
 
 from numpy import array, linspace
+from .KLIEP import KLIEP as _KLIEP
 from .RuLSIF import RuLSIF as _RuLSIF
 from .helpers import is_numeric, to_ndarray
 
@@ -63,6 +64,9 @@ def densratio(x, y, method="uLSIF", sigma="auto", lambda_="auto", alpha=0.1,
         return RuLSIF(x, y, sigma=sigma, lambda_=lambda_, alpha=alpha, kernel_num=kernel_num, verbose=verbose,
                       sigma_range=sigma_range, lambda_range=lambda_range)
 
+    if sigma_range is not None:
+        sigma = sigma_range
+
     return KLIEP(x, y, sigma=sigma, kernel_num=kernel_num, fold=fold, verbose=verbose)
 
 
@@ -93,7 +97,13 @@ def RuLSIF(x, y, sigma="auto", lambda_="auto", alpha=0.1, kernel_num=100, verbos
 
 
 def KLIEP(x, y, sigma="auto", kernel_num=100, fold=5, verbose=True):
-    raise NotImplementedError("KLIEP is not implemented yet.")
+    x = to_ndarray(x)
+    y = to_ndarray(y)
+
+    if x.shape[1] != y.shape[1]:
+        raise ValueError("x and y must be same dimensions.")
+
+    return _KLIEP(x, y, sigma=sigma, kernel_num=kernel_num, fold=fold, verbose=verbose)
 
 
 def _run_RuLSIF(x, y, alpha, sigma, lambda_, kernel_num, verbose, sigma_range=None, lambda_range=None):

--- a/densratio/density_ratio.py
+++ b/densratio/density_ratio.py
@@ -4,14 +4,17 @@ from re import sub
 
 class DensityRatio:
     """Density Ratio."""
-    def __init__(self, method, alpha, theta, lambda_, alpha_PE, alpha_KL, kernel_info, compute_density_ratio=None):
+    def __init__(self, method, alpha, theta, lambda_, alpha_PE, alpha_KL, kernel_info, compute_density_ratio=None,
+                 fold=None):
         self.method = method
         self.alpha = alpha
         self.theta = theta
+        self.kernel_weights = theta
         self.lambda_ = lambda_
         self.alpha_PE = alpha_PE
         self.alpha_KL = alpha_KL
         self.kernel_info = kernel_info
+        self.fold = fold
 
     def compute_density_ratio(self, x):
         from .RuLSIF import compute_kernel_Gaussian

--- a/tests/test_r_compatibility.py
+++ b/tests/test_r_compatibility.py
@@ -181,7 +181,6 @@ class RCompatibilityTestSuite(unittest.TestCase):
         self.assert_kernel_weights(result)
         self.assert_density_ratio_for_new_input(result)
 
-    @unittest.expectedFailure
     def test_kliep_fixed_parameter_contract(self):
         package = importlib.import_module("densratio")
 
@@ -190,6 +189,24 @@ class RCompatibilityTestSuite(unittest.TestCase):
 
         self.assertEqual(result.method, "KLIEP")
         self.assertEqual(getattr(result, "fold", None), 5)
+        self.assert_kernel_info(result)
+        self.assert_kernel_weights(result)
+        self.assert_density_ratio_for_new_input(result)
+
+    def test_densratio_accepts_method_argument_for_kliep(self):
+        np.random.seed(314)
+        result = densratio(
+            self.x,
+            self.y,
+            method="KLIEP",
+            sigma=[0.1],
+            kernel_num=20,
+            fold=5,
+            verbose=False,
+        )
+
+        self.assertEqual(result.method, "KLIEP")
+        self.assertEqual(result.fold, 5)
         self.assert_kernel_info(result)
         self.assert_kernel_weights(result)
         self.assert_density_ratio_for_new_input(result)


### PR DESCRIPTION
## Summary

- Add a KLIEP estimator implementation matching the R package structure: sigma selection, cross-validation scoring, and projected kernel-weight optimization.
- Wire the public `KLIEP()` wrapper and `densratio(..., method="KLIEP")` dispatch into the new implementation.
- Add R-compatible result metadata for `fold` and `kernel_weights`, and turn the KLIEP compatibility test from expected failure into a passing contract.

## Validation

- `python -m unittest tests.test_r_compatibility`
- `python -m unittest discover`

## Notes

- Left the existing local `.gitignore` change out of this PR.
- Did not update README because open PR #22 already owns README documentation changes.