### PR TITLE
Add changelog and release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            setup.py
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Check release tag matches package version
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          package_version="$(python setup.py --version)"
+          release_version="${GITHUB_REF_NAME#v}"
+          if [ "$package_version" != "$release_version" ]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match package version ${package_version}." >&2
+            exit 1
+          fi
+
+      - name: Build source and wheel distributions
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/densratio/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [0.4.0] - 2026-05-04
+
+This release refreshes the Python package for renewed PyPI publishing and
+brings the public API closer to the R `densratio` package.
+
+### Added
+
+- Added R-style public wrappers: `uLSIF()`, `RuLSIF()`, and `KLIEP()`.
+- Added the KLIEP density ratio estimator.
+- Added R compatibility regression tests for public API behavior and estimator
+  outputs.
+- Added a PEP 517 build configuration with `pyproject.toml`.
+- Added GitHub Actions CI for Python 3.10 through 3.14.
+- Added package extras for test, docs, and development environments.
+- Added a Trusted Publishing release workflow and release checklist.
+
+### Changed
+
+- Updated supported Python versions to Python 3.10 and newer.
+- Refined README examples and API documentation for the 0.4.0 release.
+- Replaced Travis CI with GitHub Actions.
+- Simplified development dependency installation through `requirements.txt`
+  and package extras.
+- Replaced the placeholder license file with the full MIT License text.
+
+### Fixed
+
+- Fixed RuLSIF center sampling and two-dimensional sample handling.
+- Fixed pandas `DataFrame` conversion in helper utilities.
+- Fixed `DensityRatio` pickling support.
+
+## Older Releases
+
+Older release history is available from the Git commit history and published
+PyPI releases.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,56 @@
+# Releasing
+
+This project publishes to PyPI from GitHub Actions using PyPI Trusted
+Publishing. The release workflow builds distributions on every manual run and
+publishes only when a GitHub Release is published.
+
+## One-time setup
+
+1. Configure a PyPI Trusted Publisher for the existing `densratio` project:
+   - Owner: `hoxo-m`
+   - Repository: `densratio_py`
+   - Workflow: `release.yml`
+   - Environment: `pypi`
+2. Configure the GitHub environment named `pypi` in repository settings.
+   Required reviewers are recommended for this environment.
+3. Do not add a long-lived PyPI API token to GitHub secrets. Trusted Publishing
+   uses GitHub OIDC and short-lived PyPI credentials during the release job.
+
+## Release checklist
+
+1. Update package metadata and docs:
+   - Set the next version in `setup.py`.
+   - Move release notes from `CHANGELOG.md`'s `Unreleased` section into a
+     dated version section.
+   - Update README examples if the public API changed.
+2. Run local release checks:
+
+   ```shell
+   python -m pip install -e .[dev]
+   python -m pytest
+   python -m build
+   python -m twine check dist/*
+   ```
+
+3. Open and merge a release-prep PR into `main`.
+4. Confirm the GitHub Actions CI workflow is green on `main`.
+5. Create a GitHub Release:
+   - Tag: `vX.Y.Z`, matching the package version `X.Y.Z`.
+   - Target: `main`.
+   - Title: `densratio X.Y.Z`.
+   - Body: the matching section from `CHANGELOG.md`.
+6. Publish the GitHub Release. The `Release` workflow will build the package
+   and publish it to PyPI after the `pypi` environment is approved. The
+   workflow rejects releases whose `vX.Y.Z` tag does not match the package
+   version.
+7. Verify the published package:
+
+   ```shell
+   python -m pip install --upgrade densratio==X.Y.Z
+   python -c "from densratio import densratio, uLSIF, RuLSIF, KLIEP; print('ok')"
+   ```
+
+## Manual dry run
+
+Use the `workflow_dispatch` trigger on the `Release` workflow to build and
+check distributions without publishing to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     },
     project_urls={
         'Bug Reports': 'https://github.com/hoxo-m/densratio_py/issues',
+        'Changelog': 'https://github.com/hoxo-m/densratio_py/blob/main/CHANGELOG.md',
         'Source': 'https://github.com/hoxo-m/densratio_py',
     },
     license="MIT + file LICENSE",


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with 0.4.0 release notes.
- Add `RELEASING.md` with the recommended PyPI Trusted Publishing release checklist.
- Add a GitHub Actions release workflow that builds distributions, checks metadata, and publishes to PyPI from GitHub Releases via OIDC.
- Add a `Changelog` project URL to package metadata.

## Validation
- `python setup.py --name --version`
- `git diff --check -- setup.py CHANGELOG.md RELEASING.md .github/workflows/release.yml`
- trailing whitespace check for the edited text files

## Notes
- Local `build` and `twine` are not installed in the bundled Python environment, so the actual package build was not run locally. The release workflow installs them before building.
- The unrelated local `.gitignore` change is not included.