### PR TITLE
Add README used in research section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added a README section listing research papers that used the Python package.
+
 ## [0.4.0] - 2026-05-04
 
 This release refreshes the Python package for renewed PyPI publishing and

--- a/README.md
+++ b/README.md
@@ -342,7 +342,30 @@ plt.show()
 
 ![](README_files/figure-gfm/compare-2d-5.png)<!-- -->
 
-## 5. References
+## 5. Used in research
+
+The **densratio** package has been used in several research papers,
+including:
+
+-   Kato, M., Imaizumi, M., & Minami, K. (2023). Unified Perspective on
+    Probability Divergence via the Density-Ratio Likelihood: Bridging
+    KL-Divergence and Integral Probability Metrics. *AISTATS 2023.*
+-   Nagumo, R., & Fujisawa, H. (2024). Density Ratio Estimation with
+    Doubly Strong Robustness. *ICML 2024.*
+-   Endo, H., Ikeda, S., Harada, K., Yamagata, H., Matsubara, T.,
+    Matsuo, K., Kawahara, Y., & Yamashita, O. (2024). Manifold
+    alteration between major depressive disorder and healthy control
+    subjects using dynamic mode decomposition in resting-state fMRI data.
+    *Frontiers in Psychiatry, 2024.*
+-   Wang, M., Huang, W., Gong, M., & Zhang, Z. (2025). Projection Pursuit
+    Density Ratio Estimation. *ICML 2025.*
+
+## 6. Related Work
+
+-   densratio for R <https://github.com/hoxo-m/densratio>
+-   pykliep <https://github.com/srome/pykliep>
+
+## References
 
 \[1\] Hido, S., Tsuboi, Y., Kashima, H., Sugiyama, M., & Kanamori, T.
 **Statistical outlier detection using direct density ratio estimation.**
@@ -358,8 +381,3 @@ in Machine Learning.** Cambridge University Press 2012.
 \[4\] Liu, S., Yamada, M., Collier, N., & Sugiyama, M. **Change-Point
 Detection in Time-Series Data by Relative Density-Ratio Estimation**
 Neural Networks, 2013.
-
-## 6. Related Work
-
--   densratio for R <https://github.com/hoxo-m/densratio>
--   pykliep <https://github.com/srome/pykliep>

--- a/README.rmd
+++ b/README.rmd
@@ -280,7 +280,21 @@ plt.title("Estimated Alpha-Relative Density Ratio")
 plt.show()
 ```
 
-## 5. References
+## 5. Used in research
+
+The **densratio** package has been used in several research papers, including:
+
+- Kato, M., Imaizumi, M., & Minami, K. (2023). Unified Perspective on Probability Divergence via the Density-Ratio Likelihood: Bridging KL-Divergence and Integral Probability Metrics. *AISTATS 2023.*
+- Nagumo, R., & Fujisawa, H. (2024). Density Ratio Estimation with Doubly Strong Robustness. *ICML 2024.*
+- Endo, H., Ikeda, S., Harada, K., Yamagata, H., Matsubara, T., Matsuo, K., Kawahara, Y., & Yamashita, O. (2024). Manifold alteration between major depressive disorder and healthy control subjects using dynamic mode decomposition in resting-state fMRI data. *Frontiers in Psychiatry, 2024.*
+- Wang, M., Huang, W., Gong, M., & Zhang, Z. (2025). Projection Pursuit Density Ratio Estimation. *ICML 2025.*
+
+## 6. Related Work
+
+- densratio for R https://github.com/hoxo-m/densratio
+- pykliep https://github.com/srome/pykliep
+
+## References
 
 [1] Hido, S., Tsuboi, Y., Kashima, H., Sugiyama, M., & Kanamori, T.
 **Statistical outlier detection using direct density ratio estimation.**
@@ -296,8 +310,3 @@ Cambridge University Press 2012.
 [4] Liu, S., Yamada, M., Collier, N., & Sugiyama, M.
 **Change-Point Detection in Time-Series Data by Relative Density-Ratio Estimation**
 Neural Networks, 2013.
-
-## 6. Related Work
-
-- densratio for R https://github.com/hoxo-m/densratio
-- pykliep https://github.com/srome/pykliep


### PR DESCRIPTION
## Summary
- Add a `Used in research` section to `README.Rmd` and generated `README.md`, matching the style of the R `densratio` README.
- List the four provided papers that cite or use the Python package.
- Move `Related Work` before `References` and record the documentation update in `CHANGELOG.md`.

## Validation
- `git diff --check -- README.rmd README.md CHANGELOG.md`

## Notes
- This PR only changes documentation.
- The unrelated local `.gitignore` change is not included.